### PR TITLE
Eject時にhdiutilのError表示がなされないようにした

### DIFF
--- a/ejectRAMDisk.sh
+++ b/ejectRAMDisk.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+MKRAMDISK="/Users/hayato/Scripts/mkRAMDisk.sh"
+RDIR="/Volumes/RAMDisk"
+
+if [ ! -e "${MKRAMDISK}" ]; then
+   echo "No mkramdisk found." >&2
+   exit 1
+fi
+if [ ! -e "${RDIR}" ]; then
+   echo "No RAMDisk found." >&2
+   exit 2
+fi
+
+DISKUTIL="diskutil info"
+
+DEVID="$( ${DISKUTIL} ${RDIR} | grep "Device Identifier" | awk '{print $3}' )"
+DEVNAME="$( ${DISKUTIL} ${RDIR} | grep "Part of Whole" | awk '{print $4}' )"
+
+
+CONTAINERID=$(diskutil list | grep "Apple_APFS Container" |\
+		       grep "${DEVNAME}" | awk '{print $7}')
+CONTAINERDEVNAME="$( ${DISKUTIL} ${CONTAINERID} | grep "Part of Whole" | awk '{print $4}' )"
+
+echo "RAMDisk Partition (eject 1st): ${DEVNAME}"
+echo "RAMDisk Device Name: ${DEVID}"
+echo "Container Partition Name: ${CONTAINERID}"
+echo "Container Device Name (eject 2nd): ${CONTAINERDEVNAME}"
+
+
+echo "Ejecting ${DEVNAME}..."
+hdiutil detach -force ${DEVNAME}
+
+echo "Ejecting ${CONTAINERDEVNAME}..."
+hdiutil detach -force ${CONTAINERDEVNAME}

--- a/ejectRAMDisk.sh
+++ b/ejectRAMDisk.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 MKRAMDISK="/Users/hayato/Scripts/mkRAMDisk.sh"
-RDIR="/Volumes/RAMDisk_1"
+RDIR="/Volumes/RAMDisk"
 
 if [ ! -e "${MKRAMDISK}" ]; then
    echo "No mkramdisk found." >&2
@@ -19,19 +19,8 @@ DEVID="$( ${DISKUTIL} info ${RDIR} | grep "Device Identifier" | awk '{print $3}'
 #RAMDISKデバイス名 (ex)disk2
 DEVNAME="$( ${DISKUTIL} info ${RDIR} | grep "Part of Whole" | awk '{print $4}' )"
 
-# RAMDISKパーティションを含んでいたAPFSコンテナ
-CONTAINERID=$("${DISKUTIL}" info "${DEVNAME}" | grep "APFS Physical Store" | awk '{print $4}')
-# APFSコンテナを含む物理デバイス名
-CONTAINERDEVNAME="$( ${DISKUTIL} info ${CONTAINERID} | grep "Part of Whole" | awk '{print $4}' )"
-
 echo "RAMDisk Partition (eject 1st): ${DEVNAME}"
 echo "RAMDisk Device Name: ${DEVID}"
-echo "Container Partition Name: ${CONTAINERID}"
-echo "Container Device Name (eject 2nd): ${CONTAINERDEVNAME}"
 
-
-echo "Ejecting ${DEVNAME}..."
+echo "Ejecting ..."
 hdiutil detach -force ${DEVNAME}
-
-echo "Ejecting ${CONTAINERDEVNAME}..."
-hdiutil detach -force ${CONTAINERDEVNAME}

--- a/ejectRAMDisk.sh
+++ b/ejectRAMDisk.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 MKRAMDISK="/Users/hayato/Scripts/mkRAMDisk.sh"
-RDIR="/Volumes/RAMDisk"
+RDIR="/Volumes/RAMDisk_1"
 
 if [ ! -e "${MKRAMDISK}" ]; then
    echo "No mkramdisk found." >&2
@@ -12,15 +12,17 @@ if [ ! -e "${RDIR}" ]; then
    exit 2
 fi
 
-DISKUTIL="diskutil info"
+DISKUTIL="diskutil"
 
-DEVID="$( ${DISKUTIL} ${RDIR} | grep "Device Identifier" | awk '{print $3}' )"
-DEVNAME="$( ${DISKUTIL} ${RDIR} | grep "Part of Whole" | awk '{print $4}' )"
+# RAMDISKパーティション (ex)disk2s1
+DEVID="$( ${DISKUTIL} info ${RDIR} | grep "Device Identifier" | awk '{print $3}' )"
+#RAMDISKデバイス名 (ex)disk2
+DEVNAME="$( ${DISKUTIL} info ${RDIR} | grep "Part of Whole" | awk '{print $4}' )"
 
-
-CONTAINERID=$(diskutil list | grep "Apple_APFS Container" |\
-		       grep "${DEVNAME}" | awk '{print $7}')
-CONTAINERDEVNAME="$( ${DISKUTIL} ${CONTAINERID} | grep "Part of Whole" | awk '{print $4}' )"
+# RAMDISKパーティションを含んでいたAPFSコンテナ
+CONTAINERID=$("${DISKUTIL}" info "${DEVNAME}" | grep "APFS Physical Store" | awk '{print $4}')
+# APFSコンテナを含む物理デバイス名
+CONTAINERDEVNAME="$( ${DISKUTIL} info ${CONTAINERID} | grep "Part of Whole" | awk '{print $4}' )"
 
 echo "RAMDisk Partition (eject 1st): ${DEVNAME}"
 echo "RAMDisk Device Name: ${DEVID}"


### PR DESCRIPTION
コンテナデバイスをEjectした場合、それが最後のコンテナの場合は物理APFSデバイスもEjectされるもよう